### PR TITLE
feat: add loading structure from string

### DIFF
--- a/tests/test_molgraph.py
+++ b/tests/test_molgraph.py
@@ -37,6 +37,16 @@ def test_read_xyz(tmp_path: Path) -> None:
     assert mol.elements == ["O", "H", "H"]
 
 
+def test_read_xyz_string(xyz_string=WATER_XYZ) -> None:
+    """Test reading a molecule from an XYZ string."""
+    mol = MolGraph()
+    mol.read_xyz_string(xyz_string)
+
+    assert len(mol) == 3
+    assert mol.comment == "Water molecule"
+    assert mol.elements == ["O", "H", "H"]
+
+
 def test_molecular_geometry(water_molecule: MolGraph) -> None:
     """Test molecular geometry properties."""
     mol = water_molecule


### PR DESCRIPTION
In some of my workflows where I would like to utilize the `MolGraph` class, I only had the xyz file in a string format. To avoid having to write the coordinates to a temporary file to disk only to read it in directly afterwards, I added the function `read_xyz_string`. The current implementation is a working example, where I just duplicated the `read_xyz` function and rewrote the parsing.