### PR TITLE
feat: adds method for generation and writing XYZ coordinates

### DIFF
--- a/xyz2graph/graph.py
+++ b/xyz2graph/graph.py
@@ -436,6 +436,35 @@ class MolGraph:
 
         return create_visualization(self, config)
 
+    def to_xyz(self) -> str:
+        """Convert MolGraph structure to XYZ string.
+
+        Returns:
+            str: Coordinates in XYZ format as string.
+        """
+        xyz_str = ""
+        xyz_str += f"{self[-1].index}\n"
+        xyz_str += "\n"
+        for i in self.indices:
+            row_str = ""
+            row_str += self[i - 1].element
+            row_str += f" {self[i-1].x} {self[i-1].y} {self[i-1].z}\n"
+            xyz_str += row_str
+        return xyz_str
+
+    def write_xyz(self, file_path: Union[str, Path]) -> None:
+        """Write MolGraph in XYZ format to file.
+
+        Args:
+            file_path (Union[str, Path]): Output filename of xyz file.
+
+        """
+        file_path = Path(file_path)
+
+        xyz = self.to_xyz()
+        with open(file_path, "w") as f:
+            f.write(xyz)
+
     def __len__(self) -> int:
         """Get the number of atoms in the molecule.
 


### PR DESCRIPTION
I often directly write out the coordinates from a MolGraph object after modifying the Graph. For convenience I have added the two methods `to_xyz()` and `write_xyz(output_file)`. 

`to_xyz()` returns the molecule in XYZ format as string.
`write_xyz(output_file)` writes the string directly to a specified output file.