### PR TITLE
fix(ci): drop redundant twine check from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,6 @@ jobs:
         run: pdm run mypy xyz2graph
       - name: Build package
         run: pdm build
-      - name: Check package
-        run: |
-          pdm run pip install twine
-          pdm run twine check dist/*
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- the standalone twine step broke with twine 6.2 + importlib_metadata 9 (KeyError on \`metadata['license']\`)
- pypa/gh-action-pypi-publish runs \`twine check\` internally already, so the local step is redundant
- needed before re-tagging v3.5.2