### PR TITLE
docs: badge, example, and API page fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main, develop]
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/xyz2graph.svg)](https://pypi.org/project/xyz2graph/)
 [![Python Version](https://img.shields.io/pypi/pyversions/xyz2graph.svg)](https://pypi.org/project/xyz2graph/)
-[![License](https://img.shields.io/github/license/zotko/xyz2graph.svg)](https://github.com/zotko/xyz2graph/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/zotko/xyz2graph.svg)](https://github.com/zotko/xyz2graph/blob/main/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://zotko.github.io/xyz2graph)
 [![DOI](https://zenodo.org/badge/144382005.svg)](https://doi.org/10.5281/zenodo.14569337)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/zotko/xyz2graph/main?urlpath=%2Fdoc%2Ftree%2Fbinder%2Fxyz2graph.ipynb)
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/zotko/xyz2graph/ci.yml)](https://github.com/zotko/xyz2graph/actions)
-[![codecov](https://codecov.io/gh/zotko/xyz2graph/branch/develop/graph/badge.svg?token=TXP63VKUIP)](https://codecov.io/gh/zotko/xyz2graph)
+[![codecov](https://codecov.io/gh/zotko/xyz2graph/branch/main/graph/badge.svg?token=TXP63VKUIP)](https://codecov.io/gh/zotko/xyz2graph)
 
 [![PyPI Downloads](https://static.pepy.tech/badge/xyz2graph/month)](https://pepy.tech/projects/xyz2graph)
 [![GitHub Stars](https://img.shields.io/github/stars/zotko/xyz2graph)](https://github.com/zotko/xyz2graph/stargazers)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,8 +18,9 @@ Custom output path for the HTML visualization. Defaults to input filename with .
 Launch visualization directly in default web browser instead of saving to file.
 
 **-r, --remove**  
-Remove specific atoms using comma-separated indices or element symbols (e.g., "1,2,H,O,5" removes atoms
-at positions 1,2,5 and all H,O atoms). Element symbols must be properly capitalized.
+Remove specific atoms using comma-separated atom indices (0-based) or element symbols (e.g., "1,2,H,O,5"
+removes atoms at indices 1, 2, 5 and all H, O atoms). A single value is also valid (e.g., "H" or "3").
+Element symbols should use proper capitalization; mis-cased or unknown elements are skipped with a warning.
 
 **--debug**  
 Enable verbose logging for troubleshooting and development.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,14 +41,17 @@ print(f"Graph density: {nx.density(G)}")
 Remove atoms for better visualization.
 
 ```python
-# Remove all hydrogen atoms, modifying the original structure
+# Remove all hydrogen atoms in place
 mg.remove(elements=['H'], inplace=True)
+```
 
-# Remove both hydrogen and oxygen atoms, modifying the original structure
+```python
+# Remove all hydrogen and oxygen atoms in place
 mg.remove(elements=['H', 'O'], inplace=True)
+```
 
-# Create a new molecule by removing hydrogens and specific atoms
-# The original molecule remains unchanged since inplace=False (default)
+```python
+# Return a new molecule, leaving the original unchanged (inplace=False is the default)
 new_mg = mg.remove(elements=['H'], indices=[1, 5])
 ```
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -7,4 +7,22 @@
         members_order: source           # Order methods/properties as they appear in source code
         separate_signature: true        # Show function signatures separately from docstrings
         show_signature_annotations: true # Show type hints and return types
-        heading_level: 3  
+        heading_level: 3
+
+::: xyz2graph.molecule.Atom
+    options:
+        show_root_heading: false
+        show_root_toc_entry: false
+        members_order: source
+        separate_signature: true
+        show_signature_annotations: true
+        heading_level: 3
+
+::: xyz2graph.molecule.Bond
+    options:
+        show_root_heading: false
+        show_root_toc_entry: false
+        members_order: source
+        separate_signature: true
+        show_signature_annotations: true
+        heading_level: 3


### PR DESCRIPTION
## Summary
- license and codecov badges point to main
- split remove() examples in getting started so each is self-contained
- soften CLI -r capitalization claim and note 0-based indices
- add Atom and Bond to the python API page
- run CI on push to main so codecov can track the main branch